### PR TITLE
Adding search feature to all monsters tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -544,6 +544,12 @@
           </table>
         </div>
         <div id="allMonsters" class="tab-pane fade">
+          <div class="input-group my-3">
+            <div class="input-group-prepend">
+              <label class="input-group-text" for="allMonsterSearch">Search Monsters</label>
+            </div>
+            <input id="allMonsterSearch" type="text" class="form-control" v-model="allMonsterSearch" />
+          </div>
           <table class="sortable table table-responsive-md table-striped table-dark table-bordered table-hover">
             <thead>
               <tr>
@@ -675,6 +681,7 @@
         combatChoice: "Golbin Village",
         slayerChoice: "Penumbra",
         slayerTier: "Easy",
+        allMonsterSearch: "",
         slayerAreaNegation: 0,
         dungeons: dungeonData,
         monsters: monsterData,
@@ -1033,10 +1040,9 @@
 
       findMonstersforEverything() {
         let monsterInformation = [];
-        this.monsters.forEach(element => {
-          monsterInformation.push(this.calculateMonster(element, false));
-        });
-        return monsterInformation;
+        return this.monsters.filter(element => {
+          return element.name.toLowerCase().includes(this.allMonsterSearch.toLowerCase())
+        }).map(element => this.calculateMonster(element, false))
       },
     },
     computed: {


### PR DESCRIPTION
Adding a search bar to the All Monsters tab to filter the table by monster name. Better UX, in my opinion, compared to ctrl+f and searching the page.
Example:
![Screenshot 2024-02-19 165050](https://github.com/Zxv975/CanIIdle/assets/5408375/0e7b88d7-c455-4517-85c3-da1a5ad09c8c)
